### PR TITLE
Fix perlcritic issues

### DIFF
--- a/lib/Pod/Weaver/Section/SeeAlso.pm
+++ b/lib/Pod/Weaver/Section/SeeAlso.pm
@@ -159,7 +159,7 @@ sub _make_item {
 
 	# Is it proper POD?
 	if ( $link !~ /^L\<.+\>$/ ) {
-		$link = 'L<' . $link . '>';
+		$link = 'L<' . $link . '|' . $link . '>';
 	}
 
 	return Pod::Elemental::Element::Nested->new( {


### PR DESCRIPTION
My perlcritic setup was flagging the links created by this module because the link text was not being explicitly set.  This short patch fixes it.
