### PR TITLE
Remove dependency on Moose::Autobox

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,3 +2,4 @@ Apocalypse <APOCAL@cpan.org> <apocalypse@users.noreply.github.com>
 Apocalypse <APOCAL@cpan.org> <perl@0ne.us>
 Apocalypse <APOCAL@cpan.org> <apoc@blackhole.(none)>
 Apocalypse <APOCAL@cpan.org> <apoc@satellite.(none)>
+Kent Fredric <kentnl@cpan.org> <kentfredric@gmail.com>

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Pod::Weaver::Section::SeeAlso
 
 {{$NEXT}}
+  Remove dependency on Moose::Autobox ( thanks KENTNL, GH #3 )
 
 1.003	2014-10-25 22:12:40 UTC
 

--- a/lib/Pod/Weaver/Section/SeeAlso.pm
+++ b/lib/Pod/Weaver/Section/SeeAlso.pm
@@ -3,7 +3,6 @@ package Pod::Weaver::Section::SeeAlso;
 # ABSTRACT: add a SEE ALSO pod section
 
 use Moose 1.03;
-use Moose::Autobox 0.10;
 
 with 'Pod::Weaver::Role::Section' => { -version => '3.100710' };
 
@@ -127,7 +126,7 @@ sub weave_section {
 	push( @links, $_ ) for @{ $self->links };
 
 	if ( @links ) {
-		$document->children->push(
+		push @{ $document->children },
 			Pod::Elemental::Element::Nested->new( {
 				command => 'head1',
 				content => 'SEE ALSO',
@@ -148,8 +147,7 @@ sub weave_section {
 						],
 					} ),
 				],
-			} ),
-		);
+			} );
 	}
 }
 


### PR DESCRIPTION
A whole tree of dependencies ending in something that is currently broken due to XS (>5.21.6) is a bit silly for one method call =)

https://github.com/doherty/Dist-Zilla-Plugin-Test-CPAN-Changes/pull/5
